### PR TITLE
small change to kick off github actions

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -4,7 +4,9 @@ source("2_process/src/munge_nwis_data.R")
 source("3_visualize/src/plot_timeseries.R")
 
 options(tidyverse.quiet = TRUE)
-tar_option_set(packages = c("tidyverse", "dataRetrieval")) # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
+
+# Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
+tar_option_set(packages = c("tidyverse", "dataRetrieval")) 
 
 p1_targets_list <- list(
   tar_target(site_data_01427207, download_nwis_site_data('01427207')),


### PR DESCRIPTION
Right as I was going through this course, there was [a GitHub outage and disruption of features](https://www.githubstatus.com/incidents/rmfrw9dfbtbp?utm_ts=1628610025). This meant that the github actions that detect pull request merges to advance the course was disrupted. Trying to see if I can kick them back off with this tiny, inconsequential PR.