### PR TITLE
implement phase makefiles

### DIFF
--- a/1_fetch.R
+++ b/1_fetch.R
@@ -1,0 +1,27 @@
+
+source("1_fetch/src/get_nwis_data.R")
+
+p1_targets_list <- list(
+  tar_target(p1_site_data_01427207, download_nwis_site_data('01427207')),
+  tar_target(p1_site_data_01432160, download_nwis_site_data('01432160')),
+  tar_target(p1_site_data_01435000, download_nwis_site_data('01435000')),
+  tar_target(p1_site_data_01436690, download_nwis_site_data('01436690')),
+  tar_target(p1_site_data_01466500, download_nwis_site_data('01466500')),
+  
+  tar_target(p1_site_data_csv,
+             {
+               out_file <- "1_fetch/out/site_data.csv"
+               list(p1_site_data_01427207, p1_site_data_01432160, p1_site_data_01435000,
+                    p1_site_data_01436690, p1_site_data_01466500) %>% 
+                 bind_rows() %>% 
+                 write_csv(out_file)
+               return(out_file)
+             },
+             format = "file"
+  ),
+  
+  tar_target(
+    p1_site_info,
+    nwis_site_info(p1_site_data_csv)
+  )
+)

--- a/2_process.R
+++ b/2_process.R
@@ -1,0 +1,9 @@
+
+source("2_process/src/munge_nwis_data.R")
+
+p2_targets_list <- list(
+  tar_target(
+    p2_site_data_munged,
+    munge_nwis_data(p1_site_data_csv, p1_site_info)
+  )
+)

--- a/3_visualize.R
+++ b/3_visualize.R
@@ -1,0 +1,10 @@
+
+source("3_visualize/src/plot_timeseries.R")
+
+p3_targets_list <- list(
+  tar_target(
+    p3_figure_1_png,
+    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", p2_site_data_munged),
+    format = "file"
+  )
+)

--- a/_targets.R
+++ b/_targets.R
@@ -1,52 +1,13 @@
 library(targets)
-source("1_fetch/src/get_nwis_data.R")
-source("2_process/src/munge_nwis_data.R")
-source("3_visualize/src/plot_timeseries.R")
 
 options(tidyverse.quiet = TRUE)
 
 # Loading tidyverse because we need dplyr, ggplot2, readr, stringr, and purrr
 tar_option_set(packages = c("tidyverse", "dataRetrieval")) 
 
-p1_targets_list <- list(
-  tar_target(site_data_01427207, download_nwis_site_data('01427207')),
-  tar_target(site_data_01432160, download_nwis_site_data('01432160')),
-  tar_target(site_data_01435000, download_nwis_site_data('01435000')),
-  tar_target(site_data_01436690, download_nwis_site_data('01436690')),
-  tar_target(site_data_01466500, download_nwis_site_data('01466500')),
-  
-  tar_target(site_data_csv,
-             {
-               out_file <- "1_fetch/out/site_data.csv"
-               list(site_data_01427207, site_data_01432160, site_data_01435000,
-                    site_data_01436690, site_data_01466500) %>% 
-                 bind_rows() %>% 
-                 write_csv(out_file)
-               return(out_file)
-             },
-             format = "file"
-  ),
-  
-  tar_target(
-    site_info,
-    nwis_site_info(site_data_csv)
-  )
-)
-
-p2_targets_list <- list(
-  tar_target(
-    site_data_munged,
-    munge_nwis_data(site_data_csv, site_info)
-  )
-)
-
-p3_targets_list <- list(
-  tar_target(
-    figure_1_png,
-    plot_nwis_timeseries(fileout = "3_visualize/out/figure_1.png", site_data_munged),
-    format = "file"
-  )
-)
+source("1_fetch.R")
+source("2_process.R")
+source("3_visualize.R")
 
 # Return the complete list of targets
 c(p1_targets_list, p2_targets_list, p3_targets_list)


### PR DESCRIPTION
For #11, split the top-level makefile into different phases (1_fetch, 2_process, and 3_visualize) & add the appropriate phase numbers as prefixes to all targets.